### PR TITLE
Update when multiple attribute dynamically added to select, and trigger rebuild

### DIFF
--- a/ampersand-bootstrap-multiselect-view.js
+++ b/ampersand-bootstrap-multiselect-view.js
@@ -22,11 +22,12 @@ module.exports = SelectView.extend({
   },
   render: function () {
     SelectView.prototype.render.call(this);
-    if (this.select && [ true, 'multiple' ].indexOf(this.multiple) > -1) {
-      this.select.setAttribute('multiple', 'multiple');
-    }
     this.preRenderBsPluginCb();
     $(this.select).multiselect(this.bsMultiselectOptions);
+    if (this.select && [ true, 'multiple' ].indexOf(this.multiple) > -1) {
+      this.select.setAttribute('multiple', 'multiple');
+      $(this.select).multiselect('rebuild');
+    }
     return this;
   },
   updateSelectedOption: function () {


### PR DESCRIPTION
No matter what I tried, when adding the multiple attribute dynamically, we have to trigger a multiselect rebuild.

I restructured when the multiple attribute is dynamically added, so that when triggering the rebuild it makes more sense.
